### PR TITLE
rust: page: wrap the struct page_frag in the rust

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -655,6 +655,18 @@ int rust_helper_fs_parse(struct fs_context *fc,
 }
 EXPORT_SYMBOL_GPL(rust_helper_fs_parse);
 
+void rust_helper_get_page(struct page *page)
+{
+	get_page(page);
+}
+EXPORT_SYMBOL_GPL(rust_helper_get_page);
+
+void rust_helper_put_page(struct page *page)
+{
+	put_page(page);
+}
+EXPORT_SYMBOL_GPL(rust_helper_put_page);
+
 /*
  * We use `bindgen`'s `--size_t-is-usize` option to bind the C `size_t` type
  * as the Rust `usize` type, so we can use it in contexts where Rust


### PR DESCRIPTION
Many network drivers use struct page_frag to represent an area of memory in a page. This commits wrap it in the rust.

Signed-off-by: Li Hongyu <lihongyu1999@bupt.edu.cn>